### PR TITLE
Fix no sources available to nitroless users.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ export default () => {
   return {
     onLoad() {
       log("Cumcake has been loaded!");
-      stream.ApplicationStreamSettingRequirements = original.map((obj) => {return  {...obj, userPremiumType: 0, guildPremiumTier: 0}});
+      stream.ApplicationStreamSettingRequirements = original.map(obj => {return {resolution: obj.resolution, fps: obj.fps}});
     },
     
     onUnload() {


### PR DESCRIPTION
due to setting ``userPremiumType`` and ``guildPremiumTier`` on each stream requirement, discord assumes you need atleast one tier of nitro to use it, therefore "vanilla" users cannot screenshare anymore (how ironic)